### PR TITLE
fix: Change the layout for the widget to be more responsive

### DIFF
--- a/app/src/main/java/com/infomaniak/euria/ui/widget/EuriaAppWidgetProvider.kt
+++ b/app/src/main/java/com/infomaniak/euria/ui/widget/EuriaAppWidgetProvider.kt
@@ -23,6 +23,7 @@ import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.content.Intent
+import android.os.Bundle
 import android.widget.RemoteViews
 import com.infomaniak.euria.MainActivity
 import com.infomaniak.euria.MainActivity.Companion.EXTRA_ACTION
@@ -33,10 +34,30 @@ import com.infomaniak.euria.R
 
 class EuriaAppWidgetProvider : AppWidgetProvider() {
 
-    override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
-        // We only have on widget so we use the first one
-        val appWidgetId = appWidgetIds.firstOrNull() ?: return
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+    ) {
+        if (appWidgetIds.isEmpty()) return
 
+        appWidgetIds.forEach { updateWidget(context, appWidgetManager, it) }
+    }
+
+    override fun onAppWidgetOptionsChanged(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetId: Int,
+        newOptions: Bundle,
+    ) {
+        updateWidget(context, appWidgetManager, appWidgetId)
+    }
+
+    private fun updateWidget(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetId: Int,
+    ) {
         val views = RemoteViews(context.packageName, R.layout.widget_layout)
 
         val mainIntent = getIntent(context)

--- a/app/src/main/res/layout/widget_layout.xml
+++ b/app/src/main/res/layout/widget_layout.xml
@@ -17,7 +17,7 @@
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/widget_root"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@drawable/widget_background"
     android:orientation="vertical"
@@ -50,7 +50,7 @@
     </LinearLayout>
 
     <LinearLayout
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/widgetPaddingBetweenActions"
         android:gravity="center"
@@ -58,8 +58,9 @@
 
         <FrameLayout
             android:id="@+id/ephemeralButton"
-            android:layout_width="@dimen/widgetIconSize"
+            android:layout_width="0dp"
             android:layout_height="@dimen/widgetIconSize"
+            android:layout_weight="1"
             android:background="@drawable/widget_button_background">
 
             <ImageView
@@ -72,10 +73,11 @@
 
         <FrameLayout
             android:id="@+id/microphoneButton"
-            android:layout_width="@dimen/widgetIconSize"
+            android:layout_width="0dp"
             android:layout_height="@dimen/widgetIconSize"
             android:layout_marginStart="@dimen/widgetPaddingBetweenActions"
             android:layout_marginEnd="@dimen/widgetPaddingBetweenActions"
+            android:layout_weight="1"
             android:background="@drawable/widget_button_background">
 
             <ImageView
@@ -88,8 +90,9 @@
 
         <FrameLayout
             android:id="@+id/cameraButton"
-            android:layout_width="@dimen/widgetIconSize"
+            android:layout_width="0dp"
             android:layout_height="@dimen/widgetIconSize"
+            android:layout_weight="1"
             android:background="@drawable/widget_button_background">
 
             <ImageView


### PR DESCRIPTION
Problem with previous version:

<img width="200" height="2992" alt="Screenshot_20251218_100157" src="https://github.com/user-attachments/assets/2bee6c8e-f316-4a5b-9240-e2ca3dde8780" />


On top, the updated layout with the previous widget_info.xml (widget is not deleted so it has to use the previous limitation)

<img width="200" height="2992" alt="Screenshot_20251218_095445" src="https://github.com/user-attachments/assets/feb77a04-e505-4421-a20d-8a483e50c9b0" />
