### PR TITLE
chore: Add .github/copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,10 +8,9 @@ Euria is an Android AI-assistant app (sovereign, privacy-first) built with Kotli
 ## One-Time Environment Setup
 ```bash
 git submodule update --init --recursive   # pull Core submodule — required for Gradle settings plugin
-cp env.example.properties env.properties  # fill sentryAuthToken (use a dummy value locally)
-touch uitest-env.properties               # required by CI; leave empty locally
+cp env.example.properties env.properties  # only required for Sentry release tasks; debug builds work without it
 ```
-Missing `env.properties` or `uitest-env.properties` → Gradle config phase fails.
+`uitest-env.properties` is created automatically by CI and is not required locally.
 
 ## Build & Test (CI: `.github/workflows/android.yml`)
 CI runs on every non-draft PR:
@@ -28,7 +27,7 @@ app/src/main/java/com/infomaniak/euria/
 ├── di/          # Hilt modules
 ├── network/     # ApiRepository
 ├── services/    # WorkManager workers
-├── ui/          # Compose screens; EuriaWebView + JS bridge ("euria" interface name)
+├── ui/          # Compose screens; main screen is EuriaMainScreen.kt (uses Core WebView composable + JavascriptBridge with NAME = "euria")
 Core/            # Git submodule — Infomaniak shared library
 gradle/libs.versions.toml
 ```
@@ -38,6 +37,6 @@ gradle/libs.versions.toml
 - Ensure strings are localized via `strings.xml` resources.
 - Ensure UI is written in Jetpack Compose using Material3 components.
 - `standard` flavor only: Firebase, Google services (`standardImplementation`) — fdroid builds must compile without them.
-- The WebView JS bridge interface name `"euria"` must remain stable — changing it breaks the web app integration.
+- The JavaScript bridge interface name `"euria"` (`JavascriptBridge.NAME`) must remain stable — changing it breaks the web app integration.
 - `env.properties` is git-ignored — never commit it.
 - When adding/removing a runtime dependency, update `LICENSES.md` at the repo root.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,50 @@
+# Copilot Coding Agent Onboarding — android-euria
+
+> **Read `AGENTS.md` first** for architecture, conventions, and module structure. This file focuses on build, CI, and validation.
+
+## Overview
+Euria is an Android AI-assistant app (sovereign, privacy-first) built with Kotlin + Jetpack Compose. It renders the Euria web app in a WebView with a bidirectional JavaScript bridge and adds native features (Hilt DI, WorkManager, FCM). Two build flavors: `standard` (Google Play, includes Firebase) and `fdroid`.
+
+## One-Time Environment Setup
+```bash
+git submodule update --init --recursive   # pull Core submodule — required for Gradle settings plugin
+cp env.example.properties env.properties  # fill sentryAuthToken (use a dummy value locally)
+touch uitest-env.properties               # required by CI; leave empty locally
+```
+Missing `env.properties` or `uitest-env.properties` → Gradle config phase fails.
+
+## Build
+```bash
+./gradlew assembleStandardDebug    # standard flavor
+./gradlew assembleFdroidDebug      # fdroid flavor (no Firebase)
+./gradlew build                    # all variants — same as CI
+```
+
+## Tests & Lint (CI: `.github/workflows/android.yml`)
+CI runs on every non-draft PR. It runs in order:
+```bash
+./gradlew clean
+./gradlew build
+./gradlew testFdroidDebugUnitTest testStandardDebugUnitTest --stacktrace
+```
+Replicate locally with the same sequence. Draft PRs are skipped by CI.
+
+## Project Layout
+```
+app/src/main/java/com/infomaniak/euria/
+├── data/        # LocalSettings (SharedPreferences), API models
+├── di/          # Hilt modules (dispatchers, qualifiers)
+├── network/     # ApiRepository
+├── services/    # WorkManager workers
+├── ui/          # Compose screens; EuriaWebView + JS bridge ("euria" interface name)
+Core/            # Git submodule — Infomaniak shared library
+gradle/libs.versions.toml   # all dependency versions
+settings.gradle.kts         # includes Core/build-logic via pluginManagement
+```
+
+## Rules the Agent Must Follow
+- All user-visible strings go in `res/values/strings.xml` — never hardcoded.
+- Firebase / Google services are `standardImplementation` only — fdroid must compile without them.
+- The WebView JS bridge interface name `"euria"` must remain stable.
+- `env.properties` is git-ignored — never commit it.
+- When adding/removing a runtime dependency, update `LICENSES.md` at the repo root.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Copilot Coding Agent Onboarding — android-euria
 
-> **Read `AGENTS.md` first** for architecture, conventions, and module structure. This file focuses on build, CI, and validation.
+> **Read `AGENTS.md` first** for architecture, conventions, and module structure. This file covers build, CI, and validation.
 
 ## Overview
 Euria is an Android AI-assistant app (sovereign, privacy-first) built with Kotlin + Jetpack Compose. It renders the Euria web app in a WebView with a bidirectional JavaScript bridge and adds native features (Hilt DI, WorkManager, FCM). Two build flavors: `standard` (Google Play, includes Firebase) and `fdroid`.
@@ -13,38 +13,31 @@ touch uitest-env.properties               # required by CI; leave empty locally
 ```
 Missing `env.properties` or `uitest-env.properties` → Gradle config phase fails.
 
-## Build
-```bash
-./gradlew assembleStandardDebug    # standard flavor
-./gradlew assembleFdroidDebug      # fdroid flavor (no Firebase)
-./gradlew build                    # all variants — same as CI
-```
-
-## Tests & Lint (CI: `.github/workflows/android.yml`)
-CI runs on every non-draft PR. It runs in order:
+## Build & Test (CI: `.github/workflows/android.yml`)
+CI runs on every non-draft PR:
 ```bash
 ./gradlew clean
 ./gradlew build
 ./gradlew testFdroidDebugUnitTest testStandardDebugUnitTest --stacktrace
 ```
-Replicate locally with the same sequence. Draft PRs are skipped by CI.
 
 ## Project Layout
 ```
 app/src/main/java/com/infomaniak/euria/
 ├── data/        # LocalSettings (SharedPreferences), API models
-├── di/          # Hilt modules (dispatchers, qualifiers)
+├── di/          # Hilt modules
 ├── network/     # ApiRepository
 ├── services/    # WorkManager workers
 ├── ui/          # Compose screens; EuriaWebView + JS bridge ("euria" interface name)
 Core/            # Git submodule — Infomaniak shared library
-gradle/libs.versions.toml   # all dependency versions
-settings.gradle.kts         # includes Core/build-logic via pluginManagement
+gradle/libs.versions.toml
 ```
 
-## Rules the Agent Must Follow
-- All user-visible strings go in `res/values/strings.xml` — never hardcoded.
-- Firebase / Google services are `standardImplementation` only — fdroid must compile without them.
-- The WebView JS bridge interface name `"euria"` must remain stable.
+## PR Review Instructions
+
+- Ensure strings are localized via `strings.xml` resources.
+- Ensure UI is written in Jetpack Compose using Material3 components.
+- `standard` flavor only: Firebase, Google services (`standardImplementation`) — fdroid builds must compile without them.
+- The WebView JS bridge interface name `"euria"` must remain stable — changing it breaks the web app integration.
 - `env.properties` is git-ignored — never commit it.
 - When adding/removing a runtime dependency, update `LICENSES.md` at the repo root.


### PR DESCRIPTION
## Summary
Adds `.github/copilot-instructions.md` to onboard the Copilot cloud agent to this repository.

The file covers:
- What the repository does (purpose, language, architecture)
- One-time environment setup (submodules, env files)
- Build, test, and lint commands that match CI exactly
- Project layout (key paths and modules)
- Rules to prevent common CI failures

## Related
Part of a batch PR across all Infomaniak Android repos to improve Copilot agent quality.
